### PR TITLE
use local.service_principal_id to allow values from variables.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,10 +23,6 @@ resource "random_id" "uniq" {
   byte_length = 4
 }
 
-provider "azurerm" {
-  features {}
-}
-
 resource "azurerm_resource_group" "lacework" {
   name     = local.resource_group_name
   location = local.resource_group_location
@@ -60,7 +56,7 @@ resource "azurerm_eventhub" "lacework" {
 resource "azurerm_role_assignment" "lacework" {
   scope                = azurerm_eventhub.lacework.id
   role_definition_name = "Azure Event Hubs Data Receiver"
-  principal_id         = module.az_ad_application.service_principal_id
+  principal_id         = local.service_principal_id
 
   depends_on = [azurerm_eventhub_namespace.lacework]
 }


### PR DESCRIPTION
## Summary

Module was forcing the use of local az_ad_application instead of the allowing variables.tf inputs (e.g. local.service_principal_id). Additionally the module defined a provider in `main.tf` which prevents this module from being nested inside other modules.

## How did you test this change?

Update the code to use the local.service_principal_id and provide externally configured values from `az_ad_application`.